### PR TITLE
Removing `plugins` alias where the plugins/core package is being used

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/wawandco/ox/plugins/base/help"
 	"github.com/wawandco/ox/plugins/base/test"
 	"github.com/wawandco/ox/plugins/base/version"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 	"github.com/wawandco/ox/plugins/tools/db"
 )
 
 func Test_CliTestingAliaser(t *testing.T) {
-	plugins := []plugins.Plugin{
+	plugins := []core.Plugin{
 		&generate.Command{},
 		&build.Command{},
 		&dev.Command{},

--- a/plugins/base/base.go
+++ b/plugins/base/base.go
@@ -11,13 +11,13 @@ import (
 	"github.com/wawandco/ox/plugins/base/new"
 	"github.com/wawandco/ox/plugins/base/test"
 	"github.com/wawandco/ox/plugins/base/version"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // Plugins that should be base to any OX CLI app, these provide the
 // foundation for the app to work and its where teams would hook
 // their own plugins.
-var Plugins = []plugins.Plugin{
+var Plugins = []core.Plugin{
 	&build.Command{},
 	&dev.Command{},
 	&test.Command{},

--- a/plugins/base/build/before_builder.go
+++ b/plugins/base/build/before_builder.go
@@ -3,12 +3,12 @@ package build
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // BeforeBuilder interface allows to identify the things
 // that will run before the build process has started.
 type BeforeBuilder interface {
-	plugins.Plugin
+	core.Plugin
 	RunBeforeBuild(context.Context, string, []string) error
 }

--- a/plugins/base/build/builder.go
+++ b/plugins/base/build/builder.go
@@ -3,11 +3,11 @@ package build
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // Builder interface allows to set the build steps to be run.
 type Builder interface {
-	plugins.Plugin
+	core.Plugin
 	Build(context.Context, string, []string) error
 }

--- a/plugins/base/build/command.go
+++ b/plugins/base/build/command.go
@@ -6,13 +6,13 @@ import (
 	"os"
 
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
-var _ plugins.Command = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
 
 type Command struct {
-	buildPlugins []plugins.Plugin
+	buildPlugins []core.Plugin
 
 	builders       []Builder
 	afterBuilders  []AfterBuilder
@@ -84,7 +84,7 @@ func (b *Command) Run(ctx context.Context, root string, args []string) error {
 	return nil
 }
 
-func (b *Command) Receive(plugins []plugins.Plugin) {
+func (b *Command) Receive(plugins []core.Plugin) {
 	for _, plugin := range plugins {
 		isBuildPlugin := false
 		if ptool, ok := plugin.(BeforeBuilder); ok {

--- a/plugins/base/build/flags.go
+++ b/plugins/base/build/flags.go
@@ -2,12 +2,12 @@ package build
 
 import (
 	"github.com/spf13/pflag"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 func (b *Command) ParseFlags(args []string) {
 	for _, plugin := range b.builders {
-		fp, ok := plugin.(plugins.FlagParser)
+		fp, ok := plugin.(core.FlagParser)
 		if !ok {
 			continue
 		}
@@ -19,7 +19,7 @@ func (b *Command) ParseFlags(args []string) {
 func (b *Command) Flags() *pflag.FlagSet {
 	fs := pflag.NewFlagSet("build", pflag.ContinueOnError)
 	for _, plugin := range b.buildPlugins {
-		fp, ok := plugin.(plugins.FlagParser)
+		fp, ok := plugin.(core.FlagParser)
 		if !ok {
 			continue
 		}

--- a/plugins/base/dev/command.go
+++ b/plugins/base/dev/command.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 	"golang.org/x/sync/errgroup"
 )
 
-var _ plugins.Command = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
 
 // Command is the dev command, it runs the dev plugins, each one on a different
 // go routine. the detail to what happen on each of these plugins is up to
@@ -66,7 +66,7 @@ func (d *Command) Run(ctx context.Context, root string, args []string) error {
 
 // Receive Developer and BeforeDeveloper plugins and store these
 // in the Command to be used when the command is invoked.
-func (d *Command) Receive(plugins []plugins.Plugin) {
+func (d *Command) Receive(plugins []core.Plugin) {
 	for _, tool := range plugins {
 		if ptool, ok := tool.(Developer); ok {
 			d.developers = append(d.developers, ptool)

--- a/plugins/base/dev/command_test.go
+++ b/plugins/base/dev/command_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/wawandco/ox/plugins/base/dev"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 type (
@@ -49,7 +49,7 @@ func TestCommand(t *testing.T) {
 
 	plb := plugin{}
 
-	pls := []plugins.Plugin{
+	pls := []core.Plugin{
 		&plb,
 		&developer{},
 		&beforeDeveloper{},

--- a/plugins/base/fix/fix.go
+++ b/plugins/base/fix/fix.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 //HelpText returns the help Text of build function
 
-var _ plugins.Command = (*Command)(nil)
-var _ plugins.PluginReceiver = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
+var _ core.PluginReceiver = (*Command)(nil)
 
 type Command struct {
 	fixers []Fixer
@@ -43,7 +43,7 @@ func (c *Command) Run(ctx context.Context, root string, args []string) error {
 	return nil
 }
 
-func (c *Command) Receive(plugins []plugins.Plugin) {
+func (c *Command) Receive(plugins []core.Plugin) {
 	for _, plugin := range plugins {
 		if ptool, ok := plugin.(Fixer); ok {
 			c.fixers = append(c.fixers, ptool)

--- a/plugins/base/fix/fixer.go
+++ b/plugins/base/fix/fixer.go
@@ -3,7 +3,7 @@ package fix
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // Fixer interface is created for those commands that fill fix certain
@@ -11,6 +11,6 @@ import (
 // a good way to transition from old versions of the tools into newer
 // ones
 type Fixer interface {
-	plugins.Plugin
+	core.Plugin
 	Fix(context.Context, string, []string) error
 }

--- a/plugins/base/generate/generate.go
+++ b/plugins/base/generate/generate.go
@@ -9,13 +9,13 @@ import (
 	"text/tabwriter"
 
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 //HelpText returns the help Text of build function
 
-var _ plugins.Command = (*Command)(nil)
-var _ plugins.PluginReceiver = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
+var _ core.PluginReceiver = (*Command)(nil)
 
 type Command struct {
 	generators      []Generator
@@ -84,7 +84,7 @@ func (c Command) list() {
 	fmt.Fprintf(w, "  ----\t------\n")
 	for _, plugin := range c.generators {
 		helpText := ""
-		if ht, ok := plugin.(plugins.HelpTexter); ok {
+		if ht, ok := plugin.(core.HelpTexter); ok {
 			helpText = ht.HelpText()
 		}
 
@@ -94,7 +94,7 @@ func (c Command) list() {
 	fmt.Fprintf(w, "\n")
 }
 
-func (c *Command) Receive(plugins []plugins.Plugin) {
+func (c *Command) Receive(plugins []core.Plugin) {
 	for _, plugin := range plugins {
 		ptool, ok := plugin.(Generator)
 		if !ok {

--- a/plugins/base/generate/generator.go
+++ b/plugins/base/generate/generator.go
@@ -3,13 +3,13 @@ package generate
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // Generator allows to identify those plugins that are
 // generators.
 type Generator interface {
-	plugins.Plugin
+	core.Plugin
 	InvocationName() string
 	Generate(context.Context, string, []string) error
 }
@@ -19,6 +19,6 @@ type Generator interface {
 type AfterGenerator interface {
 	// AfterGenerate receives the context and other params so it can determine if should
 	// run or not.
-	plugins.Plugin
+	core.Plugin
 	AfterGenerate(context.Context, string, []string) error
 }

--- a/plugins/base/help/command.go
+++ b/plugins/base/help/command.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 var (
 	// Help is a Command
-	_ plugins.Command = (*Command)(nil)
+	_ core.Command = (*Command)(nil)
 
 	ErrSubCommandNotFound = errors.New("subcommand not found")
 
@@ -21,7 +21,7 @@ var (
 
 // Help command that prints
 type Command struct {
-	commands []plugins.Command
+	commands []core.Command
 }
 
 func (h Command) Name() string {
@@ -56,13 +56,13 @@ func (h *Command) Run(ctx context.Context, root string, args []string) error {
 	return nil
 }
 
-func (h *Command) findCommand(args []string) (plugins.Command, []string) {
+func (h *Command) findCommand(args []string) (core.Command, []string) {
 	if len(args) < 2 {
 		return nil, nil
 	}
 
 	var commands = h.commands
-	var command plugins.Command
+	var command core.Command
 	var argIndex = 1
 	var fndNames []string
 
@@ -70,7 +70,7 @@ func (h *Command) findCommand(args []string) (plugins.Command, []string) {
 		var name = args[argIndex]
 		for _, c := range commands {
 			// TODO: If its a subcommand check also the SubcommandName
-			a, ok := c.(plugins.Aliaser)
+			a, ok := c.(core.Aliaser)
 			if !ok {
 				if c.Name() != name {
 					continue
@@ -102,7 +102,7 @@ func (h *Command) findCommand(args []string) (plugins.Command, []string) {
 			break
 		}
 
-		sc, ok := command.(plugins.Subcommander)
+		sc, ok := command.(core.Subcommander)
 		if !ok {
 			break
 		}
@@ -115,9 +115,9 @@ func (h *Command) findCommand(args []string) (plugins.Command, []string) {
 
 // Receive the plugins and stores the Commands for
 // later usage on the help text.
-func (h *Command) Receive(pl []plugins.Plugin) {
+func (h *Command) Receive(pl []core.Plugin) {
 	for _, plugin := range pl {
-		ht, ok := plugin.(plugins.Command)
+		ht, ok := plugin.(core.Command)
 		if ok && ht.ParentName() == "" {
 			h.commands = append(h.commands, ht)
 		}

--- a/plugins/base/help/command_test.go
+++ b/plugins/base/help/command_test.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 func TestFindCommand(t *testing.T) {
 	hp := Command{
-		commands: []plugins.Command{},
+		commands: []core.Command{},
 	}
 
 	migrate := &subPl{}
 	pop := &testPlugin{}
-	pop.Receive([]plugins.Plugin{
+	pop.Receive([]core.Plugin{
 		migrate,
 	})
 
@@ -45,7 +45,7 @@ func TestFindCommand(t *testing.T) {
 			"migrate",
 		}
 
-		ht, ok := result.(plugins.HelpTexter)
+		ht, ok := result.(core.HelpTexter)
 		if result.Name() != "migrate" || !ok || ht.HelpText() != migrate.HelpText() || strings.Join(names, " ") != strings.Join(expected, " ") {
 			t.Fatal("didn't find our guy")
 		}
@@ -57,7 +57,7 @@ func TestFindCommand(t *testing.T) {
 			"pop",
 			"migrate",
 		}
-		ht, ok := result.(plugins.HelpTexter)
+		ht, ok := result.(core.HelpTexter)
 		if result.Name() != "migrate" || !ok || ht.HelpText() != migrate.HelpText() || strings.Join(names, " ") != strings.Join(expected, " ") {
 			t.Fatal("didn't find our guy")
 		}
@@ -66,7 +66,7 @@ func TestFindCommand(t *testing.T) {
 }
 
 type testPlugin struct {
-	subcommands []plugins.Command
+	subcommands []core.Command
 }
 
 func (tp testPlugin) Name() string {
@@ -85,9 +85,9 @@ func (tp *testPlugin) Run(ctx context.Context, root string, args []string) error
 	return nil
 }
 
-func (tp *testPlugin) Receive(pls []plugins.Plugin) {
+func (tp *testPlugin) Receive(pls []core.Plugin) {
 	for _, pl := range pls {
-		c, ok := pl.(plugins.Command)
+		c, ok := pl.(core.Command)
 		if !ok || c.ParentName() != tp.Name() {
 			continue
 		}
@@ -96,7 +96,7 @@ func (tp *testPlugin) Receive(pls []plugins.Plugin) {
 	}
 }
 
-func (tp *testPlugin) Subcommands() []plugins.Command {
+func (tp *testPlugin) Subcommands() []core.Command {
 	return tp.subcommands
 }
 

--- a/plugins/base/help/single.go
+++ b/plugins/base/help/single.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // printSingle prints help details for a passed plugin
 // Usage, Subcommands and Flags.
-func (h *Command) printSingle(command plugins.Command, names []string) {
+func (h *Command) printSingle(command core.Command, names []string) {
 	fmt.Println("Description:")
-	if th, ok := command.(plugins.HelpTexter); ok {
+	if th, ok := command.(core.HelpTexter); ok {
 		fmt.Printf("  %v\n\n", th.HelpText())
 	}
 
@@ -24,7 +24,7 @@ func (h *Command) printSingle(command plugins.Command, names []string) {
 		usage = fmt.Sprintf("  ox %v \n", strings.Join(names, " "))
 	}
 
-	th, isSubcommander := command.(plugins.Subcommander)
+	th, isSubcommander := command.(core.Subcommander)
 	if isSubcommander {
 		usage = fmt.Sprintf("  ox %v [subcommand]\n", command.Name())
 	}
@@ -44,18 +44,18 @@ func (h *Command) printSingle(command plugins.Command, names []string) {
 			}
 
 			helpText := ""
-			if ht, ok := scomm.(plugins.HelpTexter); ok {
+			if ht, ok := scomm.(core.HelpTexter); ok {
 				helpText = ht.HelpText()
 			}
 
 			fmt.Fprintf(w, "  %v\t%v\n", scomm.Name(), helpText)
 		}
 	}
-	if th, ok := command.(plugins.Aliaser); ok {
+	if th, ok := command.(core.Aliaser); ok {
 		fmt.Printf("Alias: \n  %s\n", th.Alias())
 	}
 
-	if th, ok := command.(plugins.FlagParser); ok {
+	if th, ok := command.(core.FlagParser); ok {
 		fmt.Println("Flags:")
 
 		flags := th.Flags()

--- a/plugins/base/help/toplevel.go
+++ b/plugins/base/help/toplevel.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // printTopLevel prints the top level help text with a table that contains top level
@@ -24,11 +24,11 @@ func (h *Command) printTopLevel() {
 
 	for _, plugin := range h.commands {
 		helpText := ""
-		if ht, ok := plugin.(plugins.HelpTexter); ok {
+		if ht, ok := plugin.(core.HelpTexter); ok {
 			helpText = ht.HelpText()
 		}
 
-		if p, ok := plugin.(plugins.Aliaser); ok {
+		if p, ok := plugin.(core.Aliaser); ok {
 			fmt.Fprintf(w, "  %v\t%v\t%v\n", plugin.Name(), p.Alias(), helpText)
 		} else {
 			fmt.Fprintf(w, "  %v\t\t%v\n", plugin.Name(), helpText)

--- a/plugins/base/new/command.go
+++ b/plugins/base/new/command.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/pflag"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
-var _ plugins.Command = (*Command)(nil)
-var _ plugins.PluginReceiver = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
+var _ core.PluginReceiver = (*Command)(nil)
 var ErrNoNameProvided = errors.New("the name for the new app is needed")
 
 // Command to generate New applications.
@@ -84,7 +84,7 @@ func (d *Command) Run(ctx context.Context, root string, args []string) error {
 }
 
 // Receive and store initializers
-func (d *Command) Receive(plugins []plugins.Plugin) {
+func (d *Command) Receive(plugins []core.Plugin) {
 	for _, tool := range plugins {
 		i, ok := tool.(Initializer)
 		if ok {

--- a/plugins/base/new/command_test.go
+++ b/plugins/base/new/command_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/wawandco/ox/plugins/base/new"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 func TestRun(t *testing.T) {
@@ -19,7 +19,7 @@ func TestRun(t *testing.T) {
 
 	pl := &new.Command{}
 	tinit := &Tinit{}
-	pl.Receive([]plugins.Plugin{tinit})
+	pl.Receive([]core.Plugin{tinit})
 
 	err = pl.Run(context.Background(), root, []string{})
 	if err == nil {

--- a/plugins/base/test/after_tester.go
+++ b/plugins/base/test/after_tester.go
@@ -3,12 +3,12 @@ package test
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // AfterTester is suited for things that need to run after the tests
 // cleanup and organization things, maybe reporting or collecting metrics.
 type AfterTester interface {
-	plugins.Plugin
+	core.Plugin
 	RunAfterTest(context.Context, string, []string) error
 }

--- a/plugins/base/test/before_tester.go
+++ b/plugins/base/test/before_tester.go
@@ -3,14 +3,14 @@ package test
 import (
 	"context"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 // BeforeTester interface is suited for those tasks that need to happen
 // before the tests run, things like setting up environment variables,
 // clearing the database or other cleanup tasks.
 type BeforeTester interface {
-	plugins.Plugin
+	core.Plugin
 
 	RunBeforeTest(context.Context, string, []string) error
 }

--- a/plugins/base/test/command.go
+++ b/plugins/base/test/command.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
-var _ plugins.Plugin = (*Command)(nil)
-var _ plugins.PluginReceiver = (*Command)(nil)
-var _ plugins.Command = (*Command)(nil)
+var _ core.Plugin = (*Command)(nil)
+var _ core.PluginReceiver = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
 
 type Command struct {
 	beforeTesters []BeforeTester

--- a/plugins/base/test/plugin_receiver.go
+++ b/plugins/base/test/plugin_receiver.go
@@ -1,11 +1,11 @@
 package test
 
-import plugins "github.com/wawandco/ox/plugins/core"
+import "github.com/wawandco/ox/plugins/core"
 
 // Receive takes BeforeTesters, AfterTesters and Testers
 // from the passed list of pugins and save those in the
 // instance of Command so these get used later on.
-func (b *Command) Receive(plugins []plugins.Plugin) {
+func (b *Command) Receive(plugins []core.Plugin) {
 	for _, plugin := range plugins {
 
 		if ptool, ok := plugin.(BeforeTester); ok {

--- a/plugins/base/version/version.go
+++ b/plugins/base/version/version.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 var (
@@ -15,7 +15,7 @@ var (
 
 var (
 	// Version is a Command
-	_ plugins.Command = (*Command)(nil)
+	_ core.Command = (*Command)(nil)
 )
 
 // Command command will print X version.

--- a/plugins/tools/db/db.go
+++ b/plugins/tools/db/db.go
@@ -10,18 +10,18 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/wawandco/ox/internal/info"
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
-var _ plugins.Command = (*Command)(nil)
-var _ plugins.HelpTexter = (*Command)(nil)
-var _ plugins.PluginReceiver = (*Command)(nil)
-var _ plugins.Subcommander = (*Command)(nil)
+var _ core.Command = (*Command)(nil)
+var _ core.HelpTexter = (*Command)(nil)
+var _ core.PluginReceiver = (*Command)(nil)
+var _ core.Subcommander = (*Command)(nil)
 
 var ErrConnectionNotFound = errors.New("connection not found")
 
 type Command struct {
-	subcommands []plugins.Command
+	subcommands []core.Command
 }
 
 func (c Command) Name() string {
@@ -52,7 +52,7 @@ func (c *Command) Run(ctx context.Context, root string, args []string) error {
 	}
 
 	name := args[1]
-	var subcommand plugins.Command
+	var subcommand core.Command
 	for _, sub := range c.subcommands {
 		if sub.Name() != name {
 			continue
@@ -69,9 +69,9 @@ func (c *Command) Run(ctx context.Context, root string, args []string) error {
 	return subcommand.Run(ctx, root, args)
 }
 
-func (c *Command) Receive(pls []plugins.Plugin) {
+func (c *Command) Receive(pls []core.Plugin) {
 	for _, plugin := range pls {
-		ptool, ok := plugin.(plugins.Command)
+		ptool, ok := plugin.(core.Command)
 		if !ok || ptool.ParentName() != c.Name() {
 			continue
 		}
@@ -80,7 +80,7 @@ func (c *Command) Receive(pls []plugins.Plugin) {
 	}
 }
 
-func (c *Command) Subcommands() []plugins.Command {
+func (c *Command) Subcommands() []core.Command {
 	return c.subcommands
 }
 
@@ -98,8 +98,8 @@ func (c *Command) FindRoot() string {
 	return root
 }
 
-func Plugins() []plugins.Plugin {
-	var result []plugins.Plugin
+func Plugins() []core.Plugin {
+	var result []core.Plugin
 
 	result = append(result, &Command{})
 	result = append(result, &CreateCommand{})

--- a/plugins/tools/grift/command.go
+++ b/plugins/tools/grift/command.go
@@ -7,13 +7,13 @@ import (
 	"text/tabwriter"
 
 	"github.com/markbates/grift/grift"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 var (
 	// We want grift task to be invoked from any place.
 	// this is because of production/compiled usage of the tasks.
-	_ plugins.RootFinder = (*Command)(nil)
+	_ core.RootFinder = (*Command)(nil)
 )
 
 // Grift command is a root command to run tasks

--- a/plugins/tools/soda/generator.go
+++ b/plugins/tools/soda/generator.go
@@ -10,14 +10,14 @@ import (
 	"github.com/gobuffalo/flect"
 	"github.com/spf13/pflag"
 	"github.com/wawandco/ox/internal/log"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 var (
 	// These are the interfaces we know that this
 	// plugin must satisfy for its correct functionality
-	_ plugins.Plugin     = (*Generator)(nil)
-	_ plugins.FlagParser = (*Generator)(nil)
+	_ core.Plugin     = (*Generator)(nil)
+	_ core.FlagParser = (*Generator)(nil)
 )
 
 // Generator allows to identify model as a plugin
@@ -79,7 +79,7 @@ func (g *Generator) Flags() *pflag.FlagSet {
 	return g.flags
 }
 
-func (g *Generator) Receive(pls []plugins.Plugin) {
+func (g *Generator) Receive(pls []core.Plugin) {
 	for _, v := range pls {
 		cr, ok := v.(Creator)
 		if !ok {

--- a/plugins/tools/soda/generator_test.go
+++ b/plugins/tools/soda/generator_test.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"testing"
 
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 	"github.com/wawandco/ox/plugins/tools/soda/fizz"
 	"github.com/wawandco/ox/plugins/tools/soda/sql"
 )
 
 func Test_Generate(t *testing.T) {
 	g := Generator{}
-	g.Receive([]plugins.Plugin{&fizz.Creator{}, &sql.Creator{}})
+	g.Receive([]core.Plugin{&fizz.Creator{}, &sql.Creator{}})
 
 	t.Run("generate fizz migration", func(t *testing.T) {
 		dir := t.TempDir()

--- a/plugins/tools/soda/soda.go
+++ b/plugins/tools/soda/soda.go
@@ -2,11 +2,11 @@ package soda
 
 import (
 	"github.com/gobuffalo/packd"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
-func Plugins(migrations packd.Box) []plugins.Plugin {
-	pl := []plugins.Plugin{
+func Plugins(migrations packd.Box) []core.Plugin {
+	pl := []core.Plugin{
 		&Command{migrations: migrations},
 	}
 

--- a/plugins/tools/standard/build.go
+++ b/plugins/tools/standard/build.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/wawandco/ox/internal/info"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 )
 
 var (
 	// These are the interfaces we know that this
 	// plugin must satisfy for its correct functionality
-	_ plugins.Plugin     = (*Builder)(nil)
-	_ plugins.FlagParser = (*Builder)(nil)
+	_ core.Plugin     = (*Builder)(nil)
+	_ core.FlagParser = (*Builder)(nil)
 )
 
 type Builder struct {

--- a/plugins/tools/standard/fixer.go
+++ b/plugins/tools/standard/fixer.go
@@ -8,13 +8,13 @@ import (
 	"path/filepath"
 
 	"github.com/wawandco/ox/plugins/base/fix"
-	plugins "github.com/wawandco/ox/plugins/core"
+	"github.com/wawandco/ox/plugins/core"
 	"golang.org/x/mod/modfile"
 )
 
 var (
-	_ plugins.Plugin = (*Fixer)(nil)
-	_ fix.Fixer      = (*Fixer)(nil)
+	_ core.Plugin = (*Fixer)(nil)
+	_ fix.Fixer   = (*Fixer)(nil)
 
 	ErrModuleNameNeeded   = errors.New("module name needed")
 	ErrModuleNameNotFound = errors.New("module name not found")

--- a/plugins/tools/yarn/yarn.go
+++ b/plugins/tools/yarn/yarn.go
@@ -1,9 +1,9 @@
 package yarn
 
-import plugins "github.com/wawandco/ox/plugins/core"
+import "github.com/wawandco/ox/plugins/core"
 
 var (
-	_ plugins.Plugin = (*Plugin)(nil)
+	_ core.Plugin = (*Plugin)(nil)
 )
 
 type Plugin struct{}


### PR DESCRIPTION
This PR removes the `plugins` package alias to use the `core` keyword in places where we still used it. To do so I changed `plugins.` to be `core.` and removed the package alias on top of these files.