### PR TITLE
Removing a couple of SetEnvs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,12 +50,6 @@ func (c *cli) findCommand(name string) core.Command {
 
 // Runs the CLI or cmd/ox/main.go
 func (c *cli) Wrap(ctx context.Context, args []string) error {
-	// Not sure if we should do this here or somewhere
-	// else, these are some environment variables to be set
-	// and other things to check.
-	os.Setenv("GO111MODULE", "on") // Modules must be ON
-	os.Setenv("CGO_ENABLED", "0")  // CGO disabled
-
 	path := filepath.Join("cmd", "ox", "main.go")
 	_, err := os.Stat(path)
 	name := info.ModuleName()


### PR DESCRIPTION
This PR removes a couple of `os.SetEnvs`, we eventually should be able to remove all of them but this particular 2 may cause some issues in our users codebases. When I first added these I did not realize the impact these could have.