### PR TITLE
Updating initializer to contain the correct version of Ox 

### DIFF
--- a/internal/runtime/version.go
+++ b/internal/runtime/version.go
@@ -1,0 +1,6 @@
+package runtime
+
+var (
+	// The version of the CLI
+	Version = "v0.12.0-beta.2"
+)

--- a/plugins/base/version/version.go
+++ b/plugins/base/version/version.go
@@ -5,13 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/wawandco/ox/internal/runtime"
 	"github.com/wawandco/ox/plugins/base/content"
 	"github.com/wawandco/ox/plugins/core"
-)
-
-var (
-	// The version of the CLI
-	version = "v0.12.0-beta.2"
 )
 
 var (
@@ -41,7 +37,7 @@ func (b Command) HelpText() string {
 // Run prints the version of the ox cli
 func (b *Command) Run(ctx context.Context, root string, args []string) error {
 	fmt.Println(content.Banner)
-	fmt.Printf("Version %v\n", version)
+	fmt.Printf("Version %v\n", runtime.Version)
 
 	return nil
 }

--- a/plugins/base/version/version.go
+++ b/plugins/base/version/version.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// The version of the CLI
-	version = "v0.11.4"
+	version = "v0.12.0-beta.2"
 )
 
 var (

--- a/plugins/tools/standard/initializer.go
+++ b/plugins/tools/standard/initializer.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"path/filepath"
 
+	"github.com/wawandco/ox/internal/runtime"
 	"github.com/wawandco/ox/internal/source"
 	"github.com/wawandco/ox/plugins/base/new"
 )
@@ -22,6 +23,14 @@ func (i Initializer) Name() string {
 
 // Initialize the go module
 func (i *Initializer) Initialize(ctx context.Context, options new.Options) error {
-	err := source.Build(filepath.Join(options.Folder, "go.mod"), goModTemplate, options.Module)
+	opts := struct {
+		OxVersion  string
+		ModuleName string
+	}{
+		OxVersion:  runtime.Version,
+		ModuleName: options.Module,
+	}
+
+	err := source.Build(filepath.Join(options.Folder, "go.mod"), goModTemplate, opts)
 	return err
 }

--- a/plugins/tools/standard/initializer_test.go
+++ b/plugins/tools/standard/initializer_test.go
@@ -19,22 +19,11 @@ func TestInitializer(t *testing.T) {
 	if ini.Name() != "standard/initializer" {
 		t.Errorf("Expected 'standard/initializer' got '%s'", ini.Name())
 	}
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal("Could not get working directory")
-	}
 
-	err = os.Chdir(t.TempDir())
+	err := os.Chdir(t.TempDir())
 	if err != nil {
 		t.Fatalf("could not change to temp dir: %s", err)
 	}
-
-	t.Cleanup(func() {
-		err := os.Chdir(wd)
-		if err != nil {
-			t.Fatalf("could not change back to working directory: %s", err)
-		}
-	})
 
 	err = ini.Initialize(context.Background(), new.Options{
 		Name:   "test",

--- a/plugins/tools/standard/initializer_test.go
+++ b/plugins/tools/standard/initializer_test.go
@@ -24,8 +24,17 @@ func TestInitializer(t *testing.T) {
 		t.Fatal("Could not get working directory")
 	}
 
-	os.Chdir(t.TempDir())
-	defer os.Chdir(wd)
+	err = os.Chdir(t.TempDir())
+	if err != nil {
+		t.Fatalf("could not change to temp dir: %s", err)
+	}
+
+	t.Cleanup(func() {
+		err := os.Chdir(wd)
+		if err != nil {
+			t.Fatalf("could not change back to working directory: %s", err)
+		}
+	})
 
 	err = ini.Initialize(context.Background(), new.Options{
 		Name:   "test",

--- a/plugins/tools/standard/initializer_test.go
+++ b/plugins/tools/standard/initializer_test.go
@@ -1,0 +1,59 @@
+package standard_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wawandco/ox/internal/runtime"
+	"github.com/wawandco/ox/plugins/base/new"
+	"github.com/wawandco/ox/plugins/tools/standard"
+)
+
+func TestInitializer(t *testing.T) {
+	ini := standard.Initializer{}
+
+	if ini.Name() != "standard/initializer" {
+		t.Errorf("Expected 'standard/initializer' got '%s'", ini.Name())
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Could not get working directory")
+	}
+
+	os.Chdir(t.TempDir())
+	defer os.Chdir(wd)
+
+	err = ini.Initialize(context.Background(), new.Options{
+		Name:   "test",
+		Module: "test",
+	})
+
+	if err != nil {
+		t.Fatalf("error running initializer: %s", err)
+	}
+
+	if _, err := os.Stat("go.mod"); err != nil {
+		t.Fatalf("did not generate go.mod: %s", err)
+	}
+
+	content, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		t.Fatalf("could not read go.mod: %s", err)
+	}
+
+	contents := []string{
+		"module test",
+		fmt.Sprintf("github.com/wawandco/ox %s", runtime.Version),
+	}
+
+	scnt := string(content)
+	for _, v := range contents {
+		if !strings.Contains(scnt, v) {
+			t.Fatalf("'%s' does not contain '%s'", scnt, v)
+		}
+	}
+}

--- a/plugins/tools/standard/templates/go.mod.tmpl
+++ b/plugins/tools/standard/templates/go.mod.tmpl
@@ -1,6 +1,6 @@
-module {{.}}
+module {{.ModuleName}}
 
 require (
     github.com/gobuffalo/buffalo v0.18.1
-    github.com/wawandco/ox v0.12.0-beta.2
+    github.com/wawandco/ox {{.OxVersion}}
 )

--- a/plugins/tools/standard/templates/go.mod.tmpl
+++ b/plugins/tools/standard/templates/go.mod.tmpl
@@ -2,5 +2,5 @@ module {{.}}
 
 require (
     github.com/gobuffalo/buffalo v0.18.1
-    github.com/wawandco/ox v0.12.0-beta.1
+    github.com/wawandco/ox v0.12.0-beta.2
 )


### PR DESCRIPTION
This PR updates the standard initializer to set the correct version of Ox in the Go.mod.