### PR TITLE
Bugfix for issue #37

### DIFF
--- a/plugins/tools/soda/fizz/create_default.go
+++ b/plugins/tools/soda/fizz/create_default.go
@@ -1,12 +1,5 @@
 package fizz
 
-import (
-	"strings"
-
-	"github.com/gobuffalo/fizz"
-	"github.com/gobuffalo/flect"
-)
-
 type createDefault struct{}
 
 func (ct *createDefault) match(name string) bool {
@@ -14,38 +7,18 @@ func (ct *createDefault) match(name string) bool {
 }
 
 func (ct *createDefault) GenerateFizz(name string, args []string) (string, string, error) {
-	var up, down string
-	name = ""
+	up := `<%
+# You can add your migration from this point. For example:
+# create_table("users") {
+#   t.Column("id", "uuid", {primary: true})
+#   t.Column("email", "string", {})
+# }
+%>`
 
-	table := fizz.NewTable(name, map[string]interface{}{
-		"timestamps": false,
-	})
-
-	for _, arg := range args[0:] {
-		slice := strings.Split(arg, ":")
-		if len(slice) == 1 {
-			slice = append(slice, "string")
-		}
-
-		o := fizz.Options{}
-		name := flect.Underscore(slice[0])
-		colType := columnType(slice[1])
-
-		if name == "id" {
-			o["primary"] = true
-		}
-
-		if strings.HasPrefix(strings.ToLower(slice[1]), "nulls.") {
-			o["null"] = true
-		}
-
-		if err := table.Column(name, colType, o); err != nil {
-			return up, down, err
-		}
-	}
-
-	up = table.Fizz()
-	down = table.UnFizz()
+	down := `<%
+# You can add your migration from this point. For example:
+# drop_table("users")
+%>`
 
 	return up, down, nil
 }

--- a/plugins/tools/soda/fizz/create_default.go
+++ b/plugins/tools/soda/fizz/create_default.go
@@ -1,0 +1,51 @@
+package fizz
+
+import (
+	"strings"
+
+	"github.com/gobuffalo/fizz"
+	"github.com/gobuffalo/flect"
+)
+
+type createDefault struct{}
+
+func (ct *createDefault) match(name string) bool {
+	return false
+}
+
+func (ct *createDefault) GenerateFizz(name string, args []string) (string, string, error) {
+	var up, down string
+	name = ""
+
+	table := fizz.NewTable(name, map[string]interface{}{
+		"timestamps": false,
+	})
+
+	for _, arg := range args[0:] {
+		slice := strings.Split(arg, ":")
+		if len(slice) == 1 {
+			slice = append(slice, "string")
+		}
+
+		o := fizz.Options{}
+		name := flect.Underscore(slice[0])
+		colType := columnType(slice[1])
+
+		if name == "id" {
+			o["primary"] = true
+		}
+
+		if strings.HasPrefix(strings.ToLower(slice[1]), "nulls.") {
+			o["null"] = true
+		}
+
+		if err := table.Column(name, colType, o); err != nil {
+			return up, down, err
+		}
+	}
+
+	up = table.Fizz()
+	down = table.UnFizz()
+
+	return up, down, nil
+}

--- a/plugins/tools/soda/fizz/create_default_test.go
+++ b/plugins/tools/soda/fizz/create_default_test.go
@@ -1,0 +1,50 @@
+package fizz
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_CreateDefault_Table(t *testing.T) {
+	ac := createDefault{}
+	t.Run("with table name and no args", func(t *testing.T) {
+		up, down, err := ac.GenerateFizz("create_users", []string{})
+		if err != nil {
+			t.Error("should not be nil but got err")
+		}
+
+		expectedUP := `create_table("")`
+		expectedDown := `drop_table("")`
+
+		if !strings.Contains(up, expectedUP) {
+			t.Errorf("expected %v but got %v", expectedUP, up)
+		}
+
+		if down != expectedDown {
+			t.Errorf("expected %v but got %v", expectedDown, down)
+		}
+	})
+
+	t.Run("with table name and args", func(t *testing.T) {
+		up, down, err := ac.GenerateFizz("create_users", []string{"email"})
+		if err != nil {
+			t.Error("should not be nil but got err")
+		}
+
+		expectedUP1 := `create_table("")`
+		expectedUP2 := `t.Column("email", "string", {})`
+		expectedDown := `drop_table("")`
+
+		if !strings.Contains(up, expectedUP1) {
+			t.Errorf("expected %v but got %v", expectedUP1, up)
+		}
+
+		if !strings.Contains(up, expectedUP2) {
+			t.Errorf("expected %v but got %v", expectedUP2, up)
+		}
+
+		if down != expectedDown {
+			t.Errorf("expected %v but got %v", expectedDown, down)
+		}
+	})
+}

--- a/plugins/tools/soda/fizz/create_default_test.go
+++ b/plugins/tools/soda/fizz/create_default_test.go
@@ -7,44 +7,65 @@ import (
 
 func Test_CreateDefault_Table(t *testing.T) {
 	ac := createDefault{}
-	t.Run("with table name and no args", func(t *testing.T) {
+	t.Run("with name and no args", func(t *testing.T) {
 		up, down, err := ac.GenerateFizz("create_users", []string{})
 		if err != nil {
 			t.Error("should not be nil but got err")
 		}
 
-		expectedUP := `create_table("")`
-		expectedDown := `drop_table("")`
-
-		if !strings.Contains(up, expectedUP) {
-			t.Errorf("expected %v but got %v", expectedUP, up)
+		upContains := []string{
+			"# You can add your migration from this point. For example:",
+			`# create_table("users") {`,
+			`#   t.Column("id", "uuid", {primary: true})`,
+			`#   t.Column("email", "string", {})`,
 		}
 
-		if down != expectedDown {
-			t.Errorf("expected %v but got %v", expectedDown, down)
+		for _, c := range upContains {
+			if !strings.Contains(up, c) {
+				t.Errorf("expected %v but got %v", c, up)
+			}
+		}
+
+		downContains := []string{
+			"# You can add your migration from this point. For example:",
+			`# drop_table("users")`,
+		}
+
+		for _, c := range downContains {
+			if !strings.Contains(down, c) {
+				t.Errorf("expected %v but got %v", c, down)
+			}
 		}
 	})
 
-	t.Run("with table name and args", func(t *testing.T) {
+	t.Run("with name and args", func(t *testing.T) {
 		up, down, err := ac.GenerateFizz("create_users", []string{"email"})
 		if err != nil {
 			t.Error("should not be nil but got err")
 		}
 
-		expectedUP1 := `create_table("")`
-		expectedUP2 := `t.Column("email", "string", {})`
-		expectedDown := `drop_table("")`
-
-		if !strings.Contains(up, expectedUP1) {
-			t.Errorf("expected %v but got %v", expectedUP1, up)
+		upContains := []string{
+			"# You can add your migration from this point. For example:",
+			`# create_table("users") {`,
+			`#   t.Column("id", "uuid", {primary: true})`,
+			`#   t.Column("email", "string", {})`,
 		}
 
-		if !strings.Contains(up, expectedUP2) {
-			t.Errorf("expected %v but got %v", expectedUP2, up)
+		for _, c := range upContains {
+			if !strings.Contains(up, c) {
+				t.Errorf("expected %v but got %v", c, up)
+			}
 		}
 
-		if down != expectedDown {
-			t.Errorf("expected %v but got %v", expectedDown, down)
+		downContains := []string{
+			"# You can add your migration from this point. For example:",
+			`# drop_table("users")`,
+		}
+
+		for _, c := range downContains {
+			if !strings.Contains(down, c) {
+				t.Errorf("expected %v but got %v", c, down)
+			}
 		}
 	})
 }

--- a/plugins/tools/soda/fizz/generator.go
+++ b/plugins/tools/soda/fizz/generator.go
@@ -27,7 +27,7 @@ type MigrationGenerators []MigrationGenerator
 
 func (a MigrationGenerators) GeneratorFor(name string) MigrationGenerator {
 	// Setting create table migration by default
-	var mg MigrationGenerator = &createTable{}
+	var mg MigrationGenerator = &createDefault{}
 
 	for _, x := range a {
 		if x.match(name) {


### PR DESCRIPTION
This PR should fix an issue mentioned in issue #37 where migrations were being generated with an incorrect table name if the name of the migration is not valid.

**Update**
The generator will create both fizz files with comments and an example of a use case.