### PR TITLE
feature: migrations run on `db reset`

### DIFF
--- a/plugins/tools/soda/up.go
+++ b/plugins/tools/soda/up.go
@@ -26,6 +26,18 @@ func (mu *Command) RunUp() error {
 	return err
 }
 
+func (mu *Command) Reset(ctx context.Context, conn *pop.Connection) error {
+	pop.SetLogger(mu.Log)
+
+	mig, err := pop.NewMigrationBox(mu.migrations, conn)
+	if err != nil {
+		return err
+	}
+
+	_, err = mig.UpTo(mu.steps)
+	return err
+}
+
 func (mu *Command) RunBeforeTest(ctx context.Context, root string, args []string) error {
 	pop.SetLogger(mu.Log)
 


### PR DESCRIPTION
This PR adds the db.Resetter interface, that way we can define other resetters that will be run when db reset is invoked. It makes the migrations up command to then be a Resetter so it gets invoked by db reset.