### PR TITLE
[#47] Bugfix help command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,8 +15,8 @@ import (
 )
 
 // cli is the CLI wrapper for our tool. It is in charge
-// for articulating different commands, finding it and also
-// taking care of the CLI iteraction.
+// of articulating different commands, finding it and also
+// taking care of the CLI interaction.
 type cli struct {
 	Plugins []core.Plugin
 }
@@ -47,7 +47,7 @@ func (c *cli) findCommand(name string) core.Command {
 	return nil
 }
 
-// Runs the CLI or cmd/ox/main.go
+// Wrap Runs the CLI or cmd/ox/main.go
 func (c *cli) Wrap(ctx context.Context, args []string) error {
 	path := filepath.Join("cmd", "ox", "main.go")
 	_, err := os.Stat(path)
@@ -104,8 +104,8 @@ func (c *cli) Run(ctx context.Context, args []string) error {
 	}
 
 	// Commands that require running within the ox directory
-	// may require its root to be determined with the go.mod. However
-	// some other commands may want to determine the root by themself,
+	// may require its root to be determined with the go.mod. However,
+	// some other commands may want to determine the root by themselves,
 	// doing os.Getwd or something similar. The latter ones are RootFinders.
 	root := info.RootFolder()
 	rf, ok := command.(core.RootFinder)
@@ -120,17 +120,17 @@ func (c *cli) Run(ctx context.Context, args []string) error {
 	return command.Run(ctx, root, args[1:])
 }
 
-// Use passed Pugins by appending these to the
+// Use passed Plugins by appending these to the
 // plugins list inside the CLI.
-func (cl *cli) Use(plugins ...core.Plugin) {
-	cl.Plugins = append(cl.Plugins, plugins...)
+func (c *cli) Use(plugins ...core.Plugin) {
+	c.Plugins = append(c.Plugins, plugins...)
 }
 
 // Remove looks in the plugins list and removes plugins that
 // match passed names.
-func (cl *cli) Remove(names ...string) {
-	result := []core.Plugin{}
-	for _, pl := range cl.Plugins {
+func (c *cli) Remove(names ...string) {
+	result := make([]core.Plugin, 0)
+	for _, pl := range c.Plugins {
 		var found bool
 		for _, restricted := range names {
 			if pl.Name() == restricted {
@@ -145,10 +145,10 @@ func (cl *cli) Remove(names ...string) {
 		result = append(result, pl)
 	}
 
-	cl.Plugins = result
+	c.Plugins = result
 }
 
 // Clear the plugin list of the CLI.
-func (cl *cli) Clear() {
-	cl.Plugins = []core.Plugin{}
+func (c *cli) Clear() {
+	c.Plugins = []core.Plugin{}
 }

--- a/plugins/base/help/single.go
+++ b/plugins/base/help/single.go
@@ -11,7 +11,7 @@ import (
 
 // printSingle prints help details for a passed plugin
 // Usage, Subcommands and Flags.
-func (h *Command) printSingle(command core.Command, names []string) {
+func (c *Command) printSingle(command core.Command, names []string) {
 	fmt.Println("Description:")
 	if th, ok := command.(core.HelpTexter); ok {
 		fmt.Printf("  %v\n\n", th.HelpText())

--- a/plugins/base/help/toplevel.go
+++ b/plugins/base/help/toplevel.go
@@ -10,7 +10,7 @@ import (
 
 // printTopLevel prints the top level help text with a table that contains top level
 // commands (names) and descriptions.
-func (h *Command) printTopLevel() {
+func (c *Command) printTopLevel() {
 	fmt.Println("Usage")
 	fmt.Printf("  ox [command]\n\n")
 
@@ -22,7 +22,7 @@ func (h *Command) printTopLevel() {
 	fmt.Print("Available top level Commands:\n\n")
 	fmt.Println("Command\t     Alias")
 
-	for _, plugin := range h.commands {
+	for _, plugin := range c.commands {
 		helpText := ""
 		if ht, ok := plugin.(core.HelpTexter); ok {
 			helpText = ht.HelpText()

--- a/plugins/base/new/command.go
+++ b/plugins/base/new/command.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/pflag"
+
 	"github.com/wawandco/ox/plugins/core"
 )
 
@@ -34,7 +35,7 @@ func (d Command) ParentName() string {
 	return ""
 }
 
-//HelpText returns the help Text of build function
+// HelpText returns the help Text of build function
 func (d Command) HelpText() string {
 	return "Generates a new app with registered plugins"
 }

--- a/plugins/tools/standard/templates/go.mod.tmpl
+++ b/plugins/tools/standard/templates/go.mod.tmpl
@@ -1,6 +1,6 @@
 module {{.ModuleName}}
 
 require (
-    github.com/gobuffalo/buffalo v0.18.1
+    github.com/go/ v0.18.1
     github.com/wawandco/ox {{.OxVersion}}
 )

--- a/plugins/tools/standard/templates/go.mod.tmpl
+++ b/plugins/tools/standard/templates/go.mod.tmpl
@@ -1,6 +1,6 @@
 module {{.ModuleName}}
 
 require (
-    github.com/go/ v0.18.1
+    github.com/gobuffalo/buffalo v0.18.1
     github.com/wawandco/ox {{.OxVersion}}
 )


### PR DESCRIPTION
This PR should fix issue #47 where the CLI was returning an error after running the `help` command from a folder that does not contain a `go.mod` file.